### PR TITLE
X1-AV-25 Airbrakes Stepper/A4988 Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The Project is broken into two folders a source folder (src) and a tests folder.
 ```
 
 1. src/airbrakes.py
+   Computes a the next value to set the airbrakes to position to. Also provides a simple interface for controlling the hardware that Airbrakes uses to  deploy the brakes. It does this through a kalman filter algorithm. Please look at the kalman filter algorithm connected    to the issue X1-AV-6 [](https://github.com/UVicRocketry/Xenia1-flight-Computer/issues/14)
    
-   Computes a the next value to set the airbrakes to position to. It does this through a kalman filter algorithm. Please look at the kalman filter algorithm connected    to the issue X1-AV-6 [](https://github.com/UVicRocketry/Xenia1-flight-Computer/issues/14)
    
 2. src/dataHandler.py
 

--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -3,4 +3,8 @@
 class KalmanFilter:
   def __init__(self, rd):
     rocket_data = rd
-    
+
+class Airbrakes:
+  def __init__(self, stepper_pin, direction_pin):
+    step_pin = stepper_pin
+    dir_pin  = direction_pin

--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -85,16 +85,29 @@ class Airbrakes:
     sleep(self.step_delay)
     GPIO.output(self.step_pin, GPIO.LOW)
 
-  def deployBrakesPercent(self, percent):
+  def deployBrakes(self, percent):
 
-    # TODO get the value of the potentiometer
+    # TODO get library for ADC to read potentiometer
 
     # Convert percent to potentiometer value
-    #pot_value = ADC.read() or something
-    target_pot = (percent/100)*(self.__max_pot_val-self.__min_pot_val)
+    target_pot = __min_pot_val + (percent/100)*(self.__max_pot_val-self.__min_pot_val)
     
     steps = 0
-    while steps < self.__max_steps_to_open:
+    curr_error = target_pot-ADC.read()
+    max_error  = 10 # TODO set this based on the resolution of ADC
+
+    # Move stepper to target position within some error
+    # Prevent infinite loop by never stepping more than the max
+    while abs(curr_error) > max_err and steps < self.__max_steps_to_open:
+      
+      if curr_error < 0:
+        self.__singleStep(True)
+      else
+        self.__singleStep(False)
+
+      curr_error = target_pot-ADC.read()
+      steps += 1
+
       
 
     

--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -44,25 +44,25 @@ hardware. It is used by the KalmanFilter class.
 Attributes
 ----------
 
-__max_pot_val: Value of the potentiometer as read by the ADC when brakes are
+__max_pot_val [double]: Value of the potentiometer as read by the ADC when brakes are
 fully deployed. Set by calibrate().
 
-__min_pot_val: Value of the potentiometer as read by the ADC when brakes are
+__min_pot_val [double]: Value of the potentiometer as read by the ADC when brakes are
 fully closed. Set by calibrate().
 
-pot_pin: ADS1115 pin that is connected to potentiometer
-step_pin: GPIO pin that controls stepping of A4988 stepper driver
-dir_pin: GPIO pin that controls direction of A4988 stepper driver
+pot_pin [int]: ADS1115 pin that is connected to potentiometer
+step_pin [int]: GPIO pin that controls stepping of A4988 stepper driver
+dir_pin [int]: GPIO pin that controls direction of A4988 stepper driver
 
-motor_direction: If motor is turning the wrong direction when testing,
+motor_direction [bool]: If motor is turning the wrong direction when testing,
 invert the value of this (True/False).
 
-step_delay: Delay in seconds between pulses of step_pin
-step_angle: Step angle in degrees of stepper motor
-microsteps: 2 (half), 4 (quarter), 16 (sixteenth) etc.
-gear_ratio: (# of motor turns) / (# of gearbox output turns)
+step_delay [int]: Delay in seconds between pulses of step_pin
+step_angle [int]: Step angle in degrees of stepper motor
+microsteps [int]: 2 (half), 4 (quarter), 16 (sixteenth) etc.
+gear_ratio [int]: (# of motor turns) / (# of gearbox output turns)
 
-__max_steps_to_open: Maximum numper of steps needed to fully open the brakes.
+__max_steps_to_open [int]: Maximum numper of steps needed to fully open the brakes.
 This is calculated from the motor parameters: step_angle, microsteps, gear_ratio
 
 
@@ -71,6 +71,7 @@ Methods
 
 __singleStep():
   Steps Airbrakes stepper motor once in specified direction.
+
   Returns nothing.
 
   Param: step_direction
@@ -83,6 +84,7 @@ __singleStep():
 calibrate(): 
   Sets __max_pot_val by reading potentiometer in the fully open state
   and sets __min_pot_val by reading the potentiometer in the closed state
+
   Returns nothing.
 
   Must be called before launch (on the launch pad) to calibrate the system.
@@ -90,11 +92,12 @@ calibrate():
 deployBrakes():
   Opens the brakes to the specifed percentage of fully open.
 
+  Returns value of potentiometer at final position.
+
   Note: This uses the potentiometer for feedback so there will be a small
   error associated with this. Adjust this error by changing max_error in
   method body.
 
-  Returns value of potentiometer at final position.
 
 """
 class Airbrakes:

--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -1,10 +1,108 @@
 #this is to be imported into main and constructed with rocket_data object
+from pydoc import doc
+import RPi.GPIO as GPIO
+from time import sleep
 
+"""
+This class implements a Kalman filter to determine how far the airbrakes
+flaps should be deployed, based on sensor data and previous flight data.
+
+
+Attributes
+----------
+
+
+
+Methods
+-------
+
+
+
+
+"""
 class KalmanFilter:
   def __init__(self, rd):
     rocket_data = rd
 
+
+
+"""
+This class provides a simple way to interface with the airbrakes hardware.
+It is used by the KalmanFilter class.
+
+
+Attributes
+----------
+
+
+
+Methods
+-------
+
+
+
+
+"""
 class Airbrakes:
-  def __init__(self, stepper_pin, direction_pin):
-    step_pin = stepper_pin
-    dir_pin  = direction_pin
+  
+  # Set when calibrate() is called
+  __max_pot_val = None
+  __min_pot_val = None
+
+  def __init__(self, potentiometer_pin, stepper_pin, direction_pin,
+               direction: bool, step_angle=1.8, microsteps=16,
+               step_delay_micro_sec=75, gear_box_ratio=14):
+
+    # GPIO pins
+    self.pot_pin = potentiometer_pin
+    self.step_pin = stepper_pin
+    self.dir_pin  = direction_pin
+
+    # Stepper motor specs
+    self.motor_direction: bool = direction
+    self.step_delay = step_delay_micro_sec/1000000.0
+    self.step_angle = step_angle
+    self.microsteps = microsteps
+    self.gear_ratio = gear_box_ratio
+   
+    # Max steps to go from fully closed to fully open with 1.25 FoS
+    # Division by 6 is because airbrakes only require 1/6 of a turn to open
+    self.__max_steps_to_open = 1.25*(self.gear_ratio*(360/self.step_angle)*self.microsteps)/(6)
+
+    # Use numbering that appears on PCB
+    GPIO.setmode(GPIO.BOARD)
+
+    # Set the pins as outputs
+    GPIO.setup(self.step_pin, GPIO.OUT)
+    GPIO.setup(self.dir_pin, GPIO.OUT)
+
+  def __singleStep(self, step_direction: bool):
+
+    # ^ XORs the direction (inverting it if motor_direction dictates it)
+    GPIO.output(self.dir_pin, step_direction ^ self.motor_direction)
+
+    GPIO.output(self.step_pin, GPIO.HIGH)
+    sleep(self.step_delay)
+    GPIO.output(self.step_pin, GPIO.LOW)
+
+  def deployBrakesPercent(self, percent):
+
+    # TODO get the value of the potentiometer
+
+    # Convert percent to potentiometer value
+    #pot_value = ADC.read() or something
+    target_pot = (percent/100)*(self.__max_pot_val-self.__min_pot_val)
+    
+    steps = 0
+    while steps < self.__max_steps_to_open:
+      
+
+    
+
+
+
+
+
+
+
+

--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -27,20 +27,62 @@ class KalmanFilter:
 
 
 """
-This class provides a simple way to interface with the airbrakes hardware.
-It is used by the KalmanFilter class.
+
+Airbrakes: This class provides a simple way to interface with the airbrakes
+hardware. It is used by the KalmanFilter class.
 
 
 Attributes
 ----------
 
+__max_pot_val: Value of the potentiometer as read by the ADC when brakes are
+fully deployed. Set by calibrate().
+
+__min_pot_val: Value of the potentiometer as read by the ADC when brakes are
+fully closed. Set by calibrate().
+
+pot_pin: # TODO update this when ADC is known
+step_pin: GPIO pin that controls stepping of A4988 stepper driver
+dir_pin: GPIO pin that controls direction of A4988 stepper driver
+
+motor_direction: If motor is turning the wrong direction when testing,
+invert the value of this (True/False).
+
+step_delay: Delay in seconds between pulses of step_pin
+step_angle: Step angle in degrees of stepper motor
+microsteps: 2 (half), 4 (quarter), 16 (sixteenth) etc.
+gear_ratio: (# of motor turns) / (# of gearbox output turns)
+
+__max_steps_to_open: Maximum numper of steps needed to fully open the brakes.
+This is calculated from the motor parameters: step_angle, microsteps, gear_ratio
 
 
 Methods
 -------
 
+__singleStep():
+  Steps Airbrakes stepper motor once in specified direction.
+  Returns nothing.
 
+  Param: step_direction
+    Passing step_direction=True opens Airbrakes one step
+    Passing step_direction=False closes Airbrakes one step
 
+calibrate(): 
+  Sets __max_pot_val by reading potentiometer in the fully open state
+  and sets __min_pot_val by reading the potentiometer in the closed state
+  Returns nothing.
+
+  Must be called before launch (on the launch pad) to calibrate the system.
+
+deployBrakes():
+  Opens the brakes to the specifed percentage of fully open.
+
+  Note: This uses the potentiometer for feedback so there will be a small
+  error associated with this. Adjust this error by changing max_error in
+  method body.
+
+  Returns value of potentiometer at final position.
 
 """
 class Airbrakes:
@@ -54,7 +96,7 @@ class Airbrakes:
                step_delay_micro_sec=75, gear_box_ratio=14):
 
     # GPIO pins
-    self.pot_pin = potentiometer_pin
+    self.pot_pin = potentiometer_pin # TODO change if needed depending on ADC used
     self.step_pin = stepper_pin
     self.dir_pin  = direction_pin
 
@@ -85,9 +127,22 @@ class Airbrakes:
     sleep(self.step_delay)
     GPIO.output(self.step_pin, GPIO.LOW)
 
+  def calibrate(self):
+    
+    # Fully open brakes
+    for i in range(self.__max_steps_to_open)
+      __singleStep(True)
+    self.__max_pot_val = ADC.read()
+
+    # Fully close brakes
+    for i in range(self.__max_steps_to_open)
+      __singleStep(False)
+    self.__min_pot_val = ADC.read()
+
   def deployBrakes(self, percent):
 
-    # TODO get library for ADC to read potentiometer
+    # TODO get library for ADC to read potentiometer and change every instance
+    # of ADC.read() whatever is needed to read the value of the pot
 
     # Convert percent to potentiometer value
     target_pot = __min_pot_val + (percent/100)*(self.__max_pot_val-self.__min_pot_val)
@@ -107,6 +162,9 @@ class Airbrakes:
 
       curr_error = target_pot-ADC.read()
       steps += 1
+    
+    # Return the final potentiometer value
+    return ADC.read()
 
       
 


### PR DESCRIPTION
This adds a nice interface for controlling the Airbrakes.

Basically, you can create an Airbrakes instance, calibrate the encoder, and then deploy the flaps any percentage you want. The idea is you can use the output of the Kalman filter to control the Airbrakes cleanly. See the class comment for more info on the features.

It still needs to be tested with the assembled hardware when it arrives. There is also an error parameter called `max_error` that must be set in `deloyBrakes()` once the hardware is set up. It basically controls for how much slop there is in the mechanical system to prevent the code from taking forever to reach a desired position.

Finally this needs to be on its own thread since it utilizes the sleep function of python in between stepper steps.