### PR TITLE
Update rocketData to support airbrakes encoder

### DIFF
--- a/src/airbrakes.py
+++ b/src/airbrakes.py
@@ -93,7 +93,7 @@ calibrate():
 deployBrakes():
   Opens the brakes to the specifed percentage of fully open.
 
-  Returns value of potentiometer at final position.
+  Returns value of potentiometer/percent open at final position.
 
   Note: This uses the potentiometer for feedback so there will be a small
   error associated with this. Adjust this error by changing max_error in
@@ -197,5 +197,8 @@ class Airbrakes:
       curr_error = target_pot - self.potentiometer.value
       steps += 1
     
-    # Return the final potentiometer value
-    return self.potentiometer.value
+    percent_deployed = ((self.potentiometer.value-self.__min_pot_val)/
+              (self.__max_pot_val-self.__min_pot_val))
+
+    # Return the final potentiometer value and percentage open
+    return (self.potentiometer.value, percent_deployed)

--- a/src/rocketData.py
+++ b/src/rocketData.py
@@ -1,4 +1,5 @@
 import json
+from json import encoder
 from time import time
 
 
@@ -73,7 +74,8 @@ class RocketData:
                 12: float
             },
             'encoders': {
-                'position': float
+                'position': float,
+                'percent': float
             },
             'time_stamp': float
         }
@@ -134,11 +136,13 @@ class RocketData:
 
     @property
     def encoders(self):
-        return self._data['encoders']['position']
+        return self._data['encoders']
     
     @encoders.setter
     def encoders(self, p):
-        self._data['encoders']['position'] = p
+        pos, perc = p
+        self._data['encoders']['position'] = pos
+        self._data['encoders']['percent'] = perc 
 
     @property
     def time_stamp(self):


### PR DESCRIPTION
Here's a quick modification to the airbrakes code to make it support the rocketData better.

Basically, calling airbrakes.deployBrakes() will return the final position as a percent of full deployment, and the value of the encoder at that position as a tuple. Also, changed the encoder entry in rocketData to contain the tuple as before it was just storing the value of the encoder.

